### PR TITLE
Add Audio vorbis conversion Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ app/nicetube-linux-amd64
 .vscode/launch.json
 app/cookies.txt
 *.exe~
+/app/Videos

--- a/app/formats.go
+++ b/app/formats.go
@@ -28,6 +28,7 @@ var (
 	Q480P            = "244+ba/243+ba/242+ba/278+ba"
 	Q1440P           = "308+ba/271+ba/700+ba/400+ba/303+ba/248+ba/699+ba/399+ba/302+ba/247+ba/244+ba/243+ba/242+ba/278+ba"
 	Q2160P           = "315+ba/313+ba/701+ba/401+ba/308+ba/271+ba/700+ba/400+ba/303+ba/248+ba/699+ba/399+ba/302+ba/247+ba/244+ba/243+ba/242+ba/278+ba"
+	oggvorbis        = "bestaudio/bestaudio*"
 )
 
 func SetQuality(QualitySelector string) string {
@@ -50,6 +51,8 @@ func SetQuality(QualitySelector string) string {
 		return Q2160P
 	case "QPoggers":
 		return QPoggers
+	case "oggvorbis":
+		return oggvorbis
 	default:
 		return Q720P
 	}

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -114,10 +114,10 @@ func GetFileName(savedir string) (string, error) {
 		return "", fmt.Errorf("failed to read directory: %v", err)
 	}
 
-	// Find the .mp4 file in the directory and extract its name
+	// Edit this for file container support
 	var Videofile string
 	for _, file := range files {
-		if !file.IsDir() && (strings.HasSuffix(file.Name(), ".mp4") || strings.HasSuffix(file.Name(), ".webm") || strings.HasSuffix(file.Name(), ".mkv")) {
+		if !file.IsDir() && (strings.HasSuffix(file.Name(), ".mp4") || strings.HasSuffix(file.Name(), ".webm") || strings.HasSuffix(file.Name(), ".mkv") || strings.HasSuffix(file.Name(), ".ogg")) {
 			Videofile = file.Name()
 			break
 		}

--- a/app/main.go
+++ b/app/main.go
@@ -32,7 +32,7 @@ var disableYTDLPUpdate bool
 var currentYTDLPVersion string
 
 func main() {
-	fmt.Println("You are running version 1.0 Beta of NiceTube")
+	fmt.Println("You are running version 1.1 of NiceTube")
 	// Reading any command line flags and adjust the config
 	//When we go to docker the start up bach script should do this passing the envoirmetnal variables to the flag
 	//Not used yet

--- a/app/main.go
+++ b/app/main.go
@@ -26,6 +26,7 @@ var maxDuration int = 120
 var maxvideoage int = 24
 var cookieLocation string
 var downloadCounter int
+var audioCounter int
 var botblocked bool
 var disableYTDLPUpdate bool
 var currentYTDLPVersion string

--- a/app/resodownload.go
+++ b/app/resodownload.go
@@ -65,14 +65,25 @@ func GetResoVideos(w http.ResponseWriter, r *http.Request) {
 	if cookieset != "" {
 		args = append(args, "--cookies", cookieset)
 	}
-
-	args = append(args,
-		forceformat, QualityValue,
-		"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
-		"--ffmpeg-location", "./",
-		"-o", outputname, "--",
-		VideoURL,
-	)
+	if QualitySelector == "oggvorbis" {
+		args = append(args,
+			forceformat, QualityValue,
+			"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
+			"--ffmpeg-location", "./",
+			"-o", outputname, "--extract-audio", "--audio-format", "vorbis",
+			"--audio-quality", "5",
+			"--",
+			VideoURL,
+		)
+	} else {
+		args = append(args,
+			forceformat, QualityValue,
+			"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
+			"--ffmpeg-location", "./",
+			"-o", outputname, "--",
+			VideoURL,
+		)
+	}
 	// Reset Buffers so the botcheck clears the previous output
 	stdoutBuf.Reset()
 	stderrBuf.Reset()

--- a/app/resodownload.go
+++ b/app/resodownload.go
@@ -135,13 +135,17 @@ func GetResoVideos(w http.ResponseWriter, r *http.Request) {
 	TheDownloadURL, err = ReturnDownloadURL(savedir, Domain)
 	//fmt.Println(TheDownloadURL)
 	//http.Redirect(w, r, TheDownloadURL, http.StatusSeeOther)
-	if err != nil && botblocked != true {
+	if err != nil && !botblocked {
 		fmt.Fprintf(w, "error: No file was downloaded. Is the URL correct?")
 		return
 	}
 	fmt.Fprint(w, TheDownloadURL)
 
-	// Add a little counter that shows how many videos have been downloaded since startup. This will only count new downloads
-	downloadCounter++
-	fmt.Printf("Total Video downloads this session: %d\n", downloadCounter)
+	// Add counters based on the action.
+	if QualitySelector == "oggvorbis" {
+		audioCounter++
+	} else {
+		downloadCounter++
+	}
+	fmt.Printf("Total Video Downloads or Audio conversions this session. Videos: %d, Audio: %d\n", downloadCounter, audioCounter)
 }

--- a/app/static/js/webpanel.js
+++ b/app/static/js/webpanel.js
@@ -188,14 +188,27 @@ function addToHistory(html) {
     const timestampFormatted = new Date().toLocaleString();
     
     // Extract the quality setting from the URL
-    const quality = url.match(/\/Q\d+P(?:h264Forced)?\//) ? 
-        url.match(/\/Q\d+P(?:h264Forced)?\//).toString().replace(/\//g, '') : 
-        document.getElementById('quality')?.value || 'Unknown';
+    let quality = 'Unknown';
+    if (url.includes('/oggvorbis/')) {
+        quality = 'oggvorbis';
+    } else {
+        const qualityMatch = url.match(/\/Q\d+P(?:h264Forced)?\//)
+        if (qualityMatch) {
+            quality = qualityMatch.toString().replace(/\//g, '');
+        } else {
+            quality = document.getElementById('quality')?.value || 'Unknown';
+        }
+    }
     
     // Format quality for display
-    let qualityDisplay = quality.replace('Q', '').replace('P', 'p');
-    if (quality.includes('h264Forced')) {
-        qualityDisplay = qualityDisplay.replace('h264Forced', ' (H264)');
+    let qualityDisplay = quality;
+    if (quality.startsWith('Q')) {
+        qualityDisplay = quality.replace('Q', '').replace('P', 'p');
+        if (quality.includes('h264Forced')) {
+            qualityDisplay = qualityDisplay.replace('h264Forced', ' (H264)');
+        }
+    } else if (quality === 'oggvorbis') {
+        qualityDisplay = 'Audio (Ogg Vorbis)';
     }
     
     // Calculate when entry will expire

--- a/app/templates/webpanel.html
+++ b/app/templates/webpanel.html
@@ -66,6 +66,7 @@
                         <option value="Q480Ph264Forced">480p (H264 forced)</option>
                         <option value="Q720Ph264Forced">720p (H264 forced)</option>
                         <option value="Q1080Ph264Forced">1080p (H264 forced)</option>
+                        <option value="oggvorbis">Audio Only (Ogg Vorbis)</option>
                     </select>
                 </div>
                 


### PR DESCRIPTION
This Update bumps NiceTube to 1.1 and adds support for downloading Audio tracks and converting them into ogg vorbis for use in Resonite so the default audioclip player can be used instead of a video player. 