### PR TITLE
Add deno into docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM build-${TARGETARCH} AS build
 WORKDIR /home/Nicetube
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /home/Nicetube/extract \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,13 @@ FROM base AS build-arm64
 WORKDIR /home/Nicetube
 ADD https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_aarch64 ./yt-dlp
 ADD https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz ./ffmpeg-master-latest-linux.tar.xz
+ADD https://github.com/denoland/deno/releases/latest/download/deno-aarch64-unknown-linux-gnu.zip ./deno.zip
 
 FROM base AS build-amd64
 WORKDIR /home/Nicetube
 ADD https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux ./yt-dlp
 ADD https://github.com/yt-dlp/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz ./ffmpeg-master-latest-linux.tar.xz
+ADD https://github.com/denoland/deno/releases/latest/download/deno-x86_64-unknown-linux-gnu.zip ./deno.zip
 
 FROM build-${TARGETARCH} AS build
 WORKDIR /home/Nicetube
@@ -25,10 +27,13 @@ RUN mkdir -p /home/Nicetube/extract \
     && tar -xf /home/Nicetube/ffmpeg-master-latest-linux.tar.xz -C /home/Nicetube/extract \
     && mv $(find /home/Nicetube/extract -type f -name ffprobe) /home/Nicetube \
     && mv $(find /home/Nicetube/extract -type f -name ffmpeg) /home/Nicetube \
+    && unzip -j /home/Nicetube/deno.zip -d /home/Nicetube \
     && chmod +x /home/Nicetube/yt-dlp \
     && chmod +x /home/Nicetube/nicetube-linux-docker \
     && chmod +x /home/Nicetube/ffprobe /home/Nicetube/ffmpeg \
+    && chmod +x /home/Nicetube/deno \
     && rm -rf /home/Nicetube/ffmpeg-master-latest-linux.tar.xz \
+    && rm -rf /home/Nicetube/deno.zip \
     && rm -r ./extract
 
 RUN mkdir -p /home/Nicetube/Videos /home/Nicetube/Cookies \

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ nicetube also depends on ffmpeg and [yt-dlp](https://github.com/yt-dlp/yt-dlp#in
 1. Download the latest release for your platform into a folder you will use for nicetube
 2. Download the standalone build of [yt-dlp](https://github.com/yt-dlp/yt-dlp#installation) for your platform.
 3. Download the patched ffmpeg from [yt-dlps repo here](https://github.com/yt-dlp/FFmpeg-Builds) for your platform.
-4. Extract the binarys for ffpmpeg, ffprobe and yt-dlp into your nicetube folder.
-5. Run nicetube
+4. Download [Deno for your platform here](https://github.com/denoland/deno/releases)
+5. Extract the binarys for ffpmpeg, ffprobe, deno and yt-dlp into your nicetube folder.
+6. Run nicetube
 
 Configurable Flags can found with -help
 


### PR DESCRIPTION
Adds Deno into docker image,
No changes to nicetube as of this stage until yt-dlp says how to trigger it, if required. 