### PR TITLE
Fix deno on linux machines including docker

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -32,7 +32,7 @@ var disableYTDLPUpdate bool
 var currentYTDLPVersion string
 
 func main() {
-	fmt.Println("You are running version 1.1.2 of NiceTube")
+	fmt.Println("You are running version 1.2 of NiceTube")
 	// Reading any command line flags and adjust the config
 	//When we go to docker the start up bach script should do this passing the envoirmetnal variables to the flag
 	//Not used yet

--- a/app/resodownload.go
+++ b/app/resodownload.go
@@ -79,7 +79,7 @@ func GetResoVideos(w http.ResponseWriter, r *http.Request) {
 		args = append(args,
 			forceformat, QualityValue,
 			"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
-			"--ffmpeg-location", "./",
+			"--ffmpeg-location", "./", "--js-runtimes", "deno:./deno",
 			"-o", outputname, "--",
 			VideoURL,
 		)

--- a/app/resodownload.go
+++ b/app/resodownload.go
@@ -72,7 +72,7 @@ func GetResoVideos(w http.ResponseWriter, r *http.Request) {
 		"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
 		"--ffmpeg-location", "./"}
 
-	// Add deno runtime only on Linux
+	// Tell ytdlp where deno is only on Linux
 	if runtime.GOOS == "linux" {
 		commonArgs = append(commonArgs, "--js-runtimes", "deno:./deno")
 	}

--- a/app/resodownload.go
+++ b/app/resodownload.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"runtime"
 	"time"
 )
 
@@ -65,21 +66,28 @@ func GetResoVideos(w http.ResponseWriter, r *http.Request) {
 	if cookieset != "" {
 		args = append(args, "--cookies", cookieset)
 	}
+
+	// Common arguments here
+	commonArgs := []string{forceformat, QualityValue,
+		"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
+		"--ffmpeg-location", "./"}
+
+	// Add deno runtime only on Linux
+	if runtime.GOOS == "linux" {
+		commonArgs = append(commonArgs, "--js-runtimes", "deno:./deno")
+	}
+
 	if QualitySelector == "oggvorbis" {
+		args = append(args, commonArgs...)
 		args = append(args,
-			forceformat, QualityValue,
-			"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
-			"--ffmpeg-location", "./",
 			"-o", outputname, "--extract-audio", "--audio-format", "vorbis",
 			"--audio-quality", "5",
 			"--",
 			VideoURL,
 		)
 	} else {
+		args = append(args, commonArgs...)
 		args = append(args,
-			forceformat, QualityValue,
-			"--restrict-filenames", "--replace-in-metadata", "title", "%", "_",
-			"--ffmpeg-location", "./", "--js-runtimes", "deno:./deno",
 			"-o", outputname, "--",
 			VideoURL,
 		)


### PR DESCRIPTION
On windows deno is auto found by yt-dlp, on linux this does not happen so it must be spoon fed. 